### PR TITLE
feat: Capture promise values after they resolve

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,6 @@ module.exports = {
       },
     ],
   },
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
   testPathIgnorePatterns: ["/node_modules/", "<rootDir>/dist/", "<rootDir>/test/[^/]*/"],
 };

--- a/src/Recording.ts
+++ b/src/Recording.ts
@@ -9,6 +9,7 @@ import { makeCallEvent, makeReturnEvent } from "./event";
 import type { FunctionInfo } from "./registry";
 import { makeClassMap } from "./classMap";
 import { defaultMetadata } from "./metadata";
+import compactObject from "./util/compactObject";
 
 export default class Recording {
   constructor(type: AppMap.RecorderType, recorder: string, ...names: string[]) {
@@ -44,16 +45,25 @@ export default class Recording {
     return event;
   }
 
+  private eventUpdates: Record<number, AppMap.Event> = {};
+
+  fixup(event: AppMap.Event) {
+    this.eventUpdates[event.id] = event;
+  }
+
   abandon(): void {
     if (this.stream?.close()) rmSync(this.path);
     this.stream = undefined;
   }
 
   finish(): boolean {
-    const written = this.stream?.close({
-      classMap: makeClassMap(this.functionsSeen.keys()),
-      metadata: this.metadata,
-    });
+    const written = this.stream?.close(
+      compactObject({
+        classMap: makeClassMap(this.functionsSeen.keys()),
+        metadata: this.metadata,
+        eventUpdates: Object.keys(this.eventUpdates).length > 0 ? this.eventUpdates : undefined,
+      }),
+    );
     this.stream = undefined;
     if (written) writtenAppMaps.push(this.path);
     return !!written;

--- a/src/__tests__/Recording.test.ts
+++ b/src/__tests__/Recording.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import AppMapStream from "../AppMapStream";
+import Recording from "../Recording";
+import { makeReturnEvent } from "../event";
+import { functions } from "../registry";
+import { addTestFn } from "./helpers";
+
+describe(Recording.prototype.fixup, () => {
+  it("adds an event update to the stream", () => {
+    const recording = new Recording("process", "test", "test");
+    const funIdx = addTestFn("testFun");
+    const call = recording.functionCall(functions[funIdx], undefined, []);
+    const ret = recording.functionReturn(call.id, "result", undefined);
+    const retEvent = makeReturnEvent(ret.id, call.id, "fixed result", 31.337);
+    recording.fixup(retEvent);
+    recording.finish();
+    expect(AppMapStream.prototype.close).toBeCalledWith(
+      expect.objectContaining({
+        eventUpdates: {
+          [ret.id]: retEvent,
+        },
+      }),
+    );
+  });
+});
+
+jest.mock("../AppMapStream");

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,0 +1,12 @@
+import { identifier } from "../generate";
+import { addFunction } from "../registry";
+
+export function addTestFn(name: string, ...args: string[]): number {
+  return addFunction({
+    async: false,
+    generator: false,
+    id: identifier(name),
+    params: args.map(identifier),
+    type: "FunctionDeclaration",
+  });
+}

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import AppMap from "../AppMap";
-import { identifier } from "../generate";
 import * as recorder from "../recorder";
 import Recording from "../Recording";
-import { addFunction, functions } from "../registry";
+import { functions } from "../registry";
+import { addTestFn } from "./helpers";
 
 describe(recorder.record, () => {
   it("records the function call", () => {
@@ -39,16 +39,6 @@ afterEach(() => {
   functions.splice(0);
   jest.clearAllMocks();
 });
-
-function addTestFn(name: string, ...args: string[]): number {
-  return addFunction({
-    async: false,
-    generator: false,
-    id: identifier(name),
-    params: args.map(identifier),
-    type: "FunctionDeclaration",
-  });
-}
 
 jest.mock("../Recording");
 

--- a/test/__snapshots__/simple.test.ts.snap
+++ b/test/__snapshots__/simple.test.ts.snap
@@ -8,8 +8,20 @@ exports[`mapping a simple script 1`] = `
         {
           "children": [
             {
-              "location": "./index.js:1",
+              "location": "./index.js:13",
+              "name": "immediatePromise",
+              "static": true,
+              "type": "function",
+            },
+            {
+              "location": "./index.js:4",
               "name": "foo",
+              "static": true,
+              "type": "function",
+            },
+            {
+              "location": "./index.js:8",
+              "name": "promised",
               "static": true,
               "type": "function",
             },
@@ -22,12 +34,25 @@ exports[`mapping a simple script 1`] = `
       "type": "package",
     },
   ],
+  "eventUpdates": {
+    "4": {
+      "elapsed": 31.337,
+      "event": "return",
+      "id": 4,
+      "parent_id": 3,
+      "return_value": {
+        "class": "Promise",
+        "value": "Promise { 'promised return' }",
+      },
+      "thread_id": 0,
+    },
+  },
   "events": [
     {
       "defined_class": "",
       "event": "call",
       "id": 1,
-      "lineno": 1,
+      "lineno": 4,
       "method_id": "foo",
       "parameters": [
         {
@@ -48,6 +73,50 @@ exports[`mapping a simple script 1`] = `
       "return_value": {
         "class": "Number",
         "value": "84",
+      },
+      "thread_id": 0,
+    },
+    {
+      "defined_class": "",
+      "event": "call",
+      "id": 3,
+      "lineno": 8,
+      "method_id": "promised",
+      "parameters": [],
+      "path": "./index.js",
+      "static": true,
+      "thread_id": 0,
+    },
+    {
+      "elapsed": 31.337,
+      "event": "return",
+      "id": 4,
+      "parent_id": 3,
+      "return_value": {
+        "class": "Promise",
+        "value": "Promise { <pending> }",
+      },
+      "thread_id": 0,
+    },
+    {
+      "defined_class": "",
+      "event": "call",
+      "id": 5,
+      "lineno": 13,
+      "method_id": "immediatePromise",
+      "parameters": [],
+      "path": "./index.js",
+      "static": true,
+      "thread_id": 0,
+    },
+    {
+      "elapsed": 31.337,
+      "event": "return",
+      "id": 6,
+      "parent_id": 5,
+      "return_value": {
+        "class": "Promise",
+        "value": "Promise { 'immediate' }",
       },
       "thread_id": 0,
     },

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -49,6 +49,8 @@ export function readAppmap(path?: string): AppMap {
   if ("classMap" in result && result.classMap instanceof Array) fixClassMap(result.classMap);
   if ("metadata" in result && typeof result.metadata === "object" && result.metadata)
     fixMetadata(result.metadata as AppMap.Metadata);
+  if ("eventUpdates" in result && typeof result.eventUpdates === "object" && result.eventUpdates)
+    Object.values(result.eventUpdates).forEach(fixEvent);
 
   return result;
 }

--- a/test/simple/index.js
+++ b/test/simple/index.js
@@ -1,5 +1,19 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { setTimeout } = require("timers/promises");
+
 function foo(x) {
   return x * 2;
 }
 
+async function promised() {
+  await setTimeout(100);
+  return "promised return";
+}
+
+function immediatePromise() {
+  return Promise.resolve("immediate");
+}
+
 console.log(foo(42));
+promised().then(console.log);
+immediatePromise().then(console.log);


### PR DESCRIPTION
This change adds `eventUpdates` to fix up return values and times of promises which are still pending at return time, for example:
```json
{
 "events": [
   {
      "event": "return",
      "thread_id": 0,
      "id": 4,
      "parent_id": 3,
      "return_value": {
        "class": "Promise",
        "value": "Promise { <pending> }"
      },
      "elapsed": 0.0011802760418504477
    },
 ],
 "eventUpdates": {
    "4": {
      "event": "return",
      "thread_id": 0,
      "id": 4,
      "parent_id": 3,
      "return_value": {
        "class": "Promise",
        "value": "Promise { 'promised return' }"
      },
      "elapsed": 0.10203119507059455
    }
  }
}
```