### PR TITLE
fix: Use "javascript" as the language name in metadata

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -20,7 +20,7 @@ export const defaultMetadata: Partial<AppMap.Metadata> & { client: AppMap.Client
     url: pkg.homepage!,
   },
   language: {
-    name: "ECMAScript",
+    name: "javascript",
     engine: "Node.js",
     version: process.version,
   },

--- a/test/__snapshots__/express.test.ts.snap
+++ b/test/__snapshots__/express.test.ts.snap
@@ -125,7 +125,7 @@ exports[`mapping Express.js requests 1`] = `
     },
     "language": {
       "engine": "Node.js",
-      "name": "ECMAScript",
+      "name": "javascript",
       "version": "test node version",
     },
     "name": "test process recording",

--- a/test/__snapshots__/jest.test.ts.snap
+++ b/test/__snapshots__/jest.test.ts.snap
@@ -67,7 +67,7 @@ exports[`mapping Jest tests 1`] = `
       },
       "language": {
         "engine": "Node.js",
-        "name": "ECMAScript",
+        "name": "javascript",
         "version": "test node version",
       },
       "name": "sub subtracts numbers correctly",
@@ -144,7 +144,7 @@ exports[`mapping Jest tests 1`] = `
       },
       "language": {
         "engine": "Node.js",
-        "name": "ECMAScript",
+        "name": "javascript",
         "version": "test node version",
       },
       "name": "sum sums numbers correctly",

--- a/test/__snapshots__/mocha.test.ts.snap
+++ b/test/__snapshots__/mocha.test.ts.snap
@@ -67,7 +67,7 @@ exports[`mapping Mocha tests 1`] = `
       },
       "language": {
         "engine": "Node.js",
-        "name": "ECMAScript",
+        "name": "javascript",
         "version": "test node version",
       },
       "name": "multiply calculates power correctly",
@@ -144,7 +144,7 @@ exports[`mapping Mocha tests 1`] = `
       },
       "language": {
         "engine": "Node.js",
-        "name": "ECMAScript",
+        "name": "javascript",
         "version": "test node version",
       },
       "name": "multiply multiplies numbers correctly",

--- a/test/__snapshots__/simple.test.ts.snap
+++ b/test/__snapshots__/simple.test.ts.snap
@@ -130,7 +130,7 @@ exports[`mapping a simple script 1`] = `
     },
     "language": {
       "engine": "Node.js",
-      "name": "ECMAScript",
+      "name": "javascript",
       "version": "test node version",
     },
     "name": "test process recording",

--- a/test/__snapshots__/typescript.test.ts.snap
+++ b/test/__snapshots__/typescript.test.ts.snap
@@ -61,7 +61,7 @@ exports[`mapping a simple script 1`] = `
     },
     "language": {
       "engine": "Node.js",
-      "name": "ECMAScript",
+      "name": "javascript",
       "version": "test node version",
     },
     "name": "test process recording",


### PR DESCRIPTION
This is what the old agent used to set and apparently some of our tools recognize that name. (Yes, it is all lowercase. I considered casing it properly but I assume the tools case-sensitively look for the literal value.)