### PR TITLE
Don't crash when examining null prototype objects

### DIFF
--- a/src/__tests__/parameter.test.ts
+++ b/src/__tests__/parameter.test.ts
@@ -5,6 +5,9 @@ class Klass {
   constructor(public value: unknown) {}
 }
 
+const nullobj = Object.create(null) as Record<string, unknown>;
+nullobj.foo = "bar";
+
 const examples: [unknown, string, string, Partial<AppMap.Parameter>][] = [
   [42, "Number", "42", {}],
   [null, "object", "null", {}],
@@ -14,6 +17,12 @@ const examples: [unknown, string, string, Partial<AppMap.Parameter>][] = [
   [[], "Array", "[]", { size: 0 }],
   [[42, 43], "Array", "[ 42, 43 ]", { size: 2, items: { class: "Number" } }],
   [[42, "foo"], "Array", "[ 42, 'foo' ]", { size: 2 }],
+  [
+    nullobj,
+    "object",
+    "[Object: null prototype] { foo: 'bar' }",
+    { properties: [{ name: "foo", class: "String" }] },
+  ],
 ];
 
 describe(parameter, () => {

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -32,8 +32,8 @@ export function optParameter(value: unknown): AppMap.Parameter | undefined {
 }
 
 function getClass(value: unknown): string {
-  if (value === null) return "object";
   if (typeof value === "undefined") return "undefined";
+  if (value === null || Object.getPrototypeOf(value) === null) return "object";
   return value.constructor.name;
 }
 

--- a/test/__snapshots__/httpClient.test.ts.snap
+++ b/test/__snapshots__/httpClient.test.ts.snap
@@ -45,11 +45,22 @@ exports[`mapping http client requests 1`] = `
         {
           "class": "Object",
           "name": "target",
+          "properties": [],
           "value": "{}",
         },
         {
           "class": "Object",
           "name": "all",
+          "properties": [
+            {
+              "class": "Function",
+              "name": "SERVER_PORT",
+            },
+            {
+              "class": "Function",
+              "name": "TEST_HEADER_VALUE",
+            },
+          ],
           "value": "{
   SERVER_PORT: [Function: SERVER_PORT],
   TEST_HEADER_VALUE: [Function: TEST_HEADER_VALUE]


### PR DESCRIPTION
Objects with null prototypes don't have the usual `.constructor` property, which used to break our class detection code.