### PR TITLE
fix: Correct capitalisation of HTTP headers

### DIFF
--- a/src/hooks/http.ts
+++ b/src/hooks/http.ts
@@ -156,10 +156,13 @@ function normalizeHeaders(
 ): Record<string, string> | undefined {
   const result: Record<string, string> = {};
 
-  for (const [k, v] of Object.entries(headers))
+  for (const [k, v] of Object.entries(headers)) {
     if (v === undefined) continue;
-    else if (v instanceof Array) result[k] = v.join("\n");
-    else result[k] = String(v);
+
+    const key = k.split("-").map(capitalize).join("-");
+    if (v instanceof Array) result[key] = v.join("\n");
+    else result[key] = String(v);
+  }
 
   return result;
 }
@@ -175,4 +178,8 @@ function handleResponse(
     response.statusCode,
     normalizeHeaders(response.getHeaders()),
   );
+}
+
+function capitalize(str: string): string {
+  return str[0].toUpperCase() + str.slice(1).toLowerCase();
 }

--- a/test/__snapshots__/express.test.ts.snap
+++ b/test/__snapshots__/express.test.ts.snap
@@ -39,9 +39,9 @@ exports[`mapping Express.js requests 1`] = `
       "event": "call",
       "http_server_request": {
         "headers": {
-          "content-type": "application/json",
-          "host": "localhost:27627",
-          "transfer-encoding": "chunked",
+          "Content-Type": "application/json",
+          "Host": "localhost:27627",
+          "Transfer-Encoding": "chunked",
         },
         "normalized_path_info": "/api/:ident",
         "path_info": "/api/bar",
@@ -109,7 +109,7 @@ exports[`mapping Express.js requests 1`] = `
       "event": "call",
       "http_server_request": {
         "headers": {
-          "host": "localhost:27627",
+          "Host": "localhost:27627",
         },
         "normalized_path_info": "/api/:ident",
         "path_info": "/api/foo",
@@ -142,7 +142,7 @@ exports[`mapping Express.js requests 1`] = `
       "event": "call",
       "http_server_request": {
         "headers": {
-          "host": "localhost:27627",
+          "Host": "localhost:27627",
         },
         "path_info": "/",
         "protocol": "HTTP/1.1",
@@ -191,10 +191,10 @@ exports[`mapping Express.js requests 1`] = `
       "event": "return",
       "http_server_response": {
         "headers": {
-          "content-length": "12",
-          "content-type": "text/html; charset=utf-8",
-          "etag": "W/"c-Lve95gjOVATpfV8EL5X4nxwjKHE"",
-          "x-powered-by": "Express",
+          "Content-Length": "12",
+          "Content-Type": "text/html; charset=utf-8",
+          "Etag": "W/"c-Lve95gjOVATpfV8EL5X4nxwjKHE"",
+          "X-Powered-By": "Express",
         },
         "status_code": 200,
       },
@@ -206,7 +206,7 @@ exports[`mapping Express.js requests 1`] = `
       "event": "call",
       "http_server_request": {
         "headers": {
-          "host": "localhost:27627",
+          "Host": "localhost:27627",
         },
         "path_info": "/nonexistent",
         "protocol": "HTTP/1.1",
@@ -220,11 +220,11 @@ exports[`mapping Express.js requests 1`] = `
       "event": "return",
       "http_server_response": {
         "headers": {
-          "content-length": "150",
-          "content-security-policy": "default-src 'none'",
-          "content-type": "text/html; charset=utf-8",
-          "x-content-type-options": "nosniff",
-          "x-powered-by": "Express",
+          "Content-Length": "150",
+          "Content-Security-Policy": "default-src 'none'",
+          "Content-Type": "text/html; charset=utf-8",
+          "X-Content-Type-Options": "nosniff",
+          "X-Powered-By": "Express",
         },
         "status_code": 404,
       },
@@ -236,7 +236,7 @@ exports[`mapping Express.js requests 1`] = `
       "event": "call",
       "http_server_request": {
         "headers": {
-          "host": "localhost:27627",
+          "Host": "localhost:27627",
         },
         "path_info": "/api/foo",
         "protocol": "HTTP/1.1",
@@ -316,10 +316,10 @@ exports[`mapping Express.js requests 1`] = `
       "event": "return",
       "http_server_response": {
         "headers": {
-          "content-length": "42",
-          "content-type": "application/json; charset=utf-8",
-          "etag": "W/"2a-YHNH/nKM8UUG4pNEEtm91sktuKc"",
-          "x-powered-by": "Express",
+          "Content-Length": "42",
+          "Content-Type": "application/json; charset=utf-8",
+          "Etag": "W/"2a-YHNH/nKM8UUG4pNEEtm91sktuKc"",
+          "X-Powered-By": "Express",
         },
         "status_code": 200,
       },
@@ -331,9 +331,9 @@ exports[`mapping Express.js requests 1`] = `
       "event": "call",
       "http_server_request": {
         "headers": {
-          "content-type": "application/json",
-          "host": "localhost:27627",
-          "transfer-encoding": "chunked",
+          "Content-Type": "application/json",
+          "Host": "localhost:27627",
+          "Transfer-Encoding": "chunked",
         },
         "path_info": "/api/bar",
         "protocol": "HTTP/1.1",
@@ -467,10 +467,10 @@ exports[`mapping Express.js requests 1`] = `
       "event": "return",
       "http_server_response": {
         "headers": {
-          "content-length": "99",
-          "content-type": "application/json; charset=utf-8",
-          "etag": "W/"63-avsgRi3I+MK54okDiWb1V4/K3j8"",
-          "x-powered-by": "Express",
+          "Content-Length": "99",
+          "Content-Type": "application/json; charset=utf-8",
+          "Etag": "W/"63-avsgRi3I+MK54okDiWb1V4/K3j8"",
+          "X-Powered-By": "Express",
         },
         "status_code": 200,
       },

--- a/test/__snapshots__/httpClient.test.ts.snap
+++ b/test/__snapshots__/httpClient.test.ts.snap
@@ -64,8 +64,8 @@ exports[`mapping http client requests 1`] = `
       "event": "call",
       "http_client_request": {
         "headers": {
-          "host": "localhost:27628",
-          "test-header": "This test header is added after ClientRequest creation",
+          "Host": "localhost:27628",
+          "Test-Header": "This test header is added after ClientRequest creation",
         },
         "request_method": "GET",
         "url": "http://localhost:27628/endpoint/one",
@@ -78,7 +78,7 @@ exports[`mapping http client requests 1`] = `
       "event": "return",
       "http_client_response": {
         "headers": {
-          "transfer-encoding": "chunked",
+          "Transfer-Encoding": "chunked",
         },
         "status_code": 200,
       },
@@ -90,8 +90,8 @@ exports[`mapping http client requests 1`] = `
       "event": "call",
       "http_client_request": {
         "headers": {
-          "content-type": "application/json",
-          "host": "localhost:27628",
+          "Content-Type": "application/json",
+          "Host": "localhost:27628",
         },
         "request_method": "POST",
         "url": "http://localhost:27628/endpoint/two",
@@ -104,8 +104,8 @@ exports[`mapping http client requests 1`] = `
       "event": "return",
       "http_client_response": {
         "headers": {
-          "content-type": "text/html",
-          "transfer-encoding": "chunked",
+          "Content-Type": "text/html",
+          "Transfer-Encoding": "chunked",
         },
         "status_code": 404,
       },
@@ -117,7 +117,7 @@ exports[`mapping http client requests 1`] = `
       "event": "call",
       "http_client_request": {
         "headers": {
-          "host": "localhost:27628",
+          "Host": "localhost:27628",
         },
         "request_method": "GET",
         "url": "http://localhost:27628/endpoint/three",
@@ -130,8 +130,8 @@ exports[`mapping http client requests 1`] = `
       "event": "return",
       "http_client_response": {
         "headers": {
-          "content-type": "text/html",
-          "transfer-encoding": "chunked",
+          "Content-Type": "text/html",
+          "Transfer-Encoding": "chunked",
         },
         "status_code": 404,
       },

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -83,10 +83,10 @@ function fixEvent(event: unknown) {
     "headers" in event.http_server_request &&
     typeof event.http_server_request.headers === "object" &&
     event.http_server_request.headers &&
-    "connection" in event.http_server_request.headers
+    "Connection" in event.http_server_request.headers
   )
     // the default of this varies between node versions
-    delete event.http_server_request.headers.connection;
+    delete event.http_server_request.headers.Connection;
 
   if (
     "http_client_response" in event &&
@@ -96,12 +96,12 @@ function fixEvent(event: unknown) {
     typeof event.http_client_response.headers === "object" &&
     event.http_client_response.headers
   ) {
-    if ("date" in event.http_client_response.headers)
-      delete event.http_client_response.headers.date;
-    if ("connection" in event.http_client_response.headers)
-      delete event.http_client_response.headers.connection;
-    if ("keep-alive" in event.http_client_response.headers)
-      delete event.http_client_response.headers["keep-alive"];
+    if ("Date" in event.http_client_response.headers)
+      delete event.http_client_response.headers.Date;
+    if ("Connection" in event.http_client_response.headers)
+      delete event.http_client_response.headers.Connection;
+    if ("Keep-Alive" in event.http_client_response.headers)
+      delete event.http_client_response.headers["Keep-Alive"];
   }
   if ("elapsed" in event && typeof event.elapsed === "number") event.elapsed = 31.337;
 }


### PR DESCRIPTION
Node lower-cases HTTP headers, but in AppMaps they should have the canonical capitalisation (X-Like-This).