### PR TITLE
fix: Fill in defined_class field even for free functions

### DIFF
--- a/src/__tests__/classMap.test.ts
+++ b/src/__tests__/classMap.test.ts
@@ -6,11 +6,10 @@ describe(makeClassMap, () => {
   it("creates a classmap from functions", () => {
     const functions: FunctionInfo[] = [
       f("method", "/test/app/src/util.js:17", "Util", false),
-      f("otherFunction", "/test/app/src/util.js:3"),
-      f("foo", "/test/app/src/foo.js:3"),
-      f("noLocation"),
-      f("freeFunction", "/test/app/src/util.js:1"),
-      f("otherFunction", "/test/app/src/util/other.js:1"),
+      f("otherFunction", "/test/app/src/util.js:3", "util"),
+      f("foo", "/test/app/src/foo.js:3", "foo"),
+      f("freeFunction", "/test/app/src/util.js:1", "util"),
+      f("otherFunction", "/test/app/src/util/other.js:1", "other"),
       f("statik", "/test/app/src/util.js:14", "Util"),
     ];
 
@@ -94,8 +93,8 @@ describe(makeClassMap, () => {
 
 function f(
   id: string,
-  loc?: string,
-  klass?: string,
+  loc: string,
+  klass: string,
   static_ = true,
   async = false,
   generator = false,
@@ -111,7 +110,7 @@ function f(
     id,
     params: [],
     static: static_,
-    klass,
+    klassOrPkg: klass,
     location,
   };
 }

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -2,11 +2,14 @@ import { identifier } from "../generate";
 import { FunctionInfo, createFunctionInfo } from "../registry";
 
 export function createTestFn(name: string, ...args: string[]): FunctionInfo {
-  return createFunctionInfo({
-    async: false,
-    generator: false,
-    id: identifier(name),
-    params: args.map(identifier),
-    type: "FunctionDeclaration",
-  });
+  return createFunctionInfo(
+    {
+      async: false,
+      generator: false,
+      id: identifier(name),
+      params: args.map(identifier),
+      type: "FunctionDeclaration",
+    },
+    { path: "test.js", lineno: 42 },
+  );
 }

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -3,21 +3,25 @@ import * as registry from "../registry";
 
 describe(registry.createFunctionInfo, () => {
   it("creates a function info", () => {
-    const functionInfo = registry.createFunctionInfo({
-      async: false,
-      generator: false,
-      id: identifier("testFun"),
-      params: [],
-      type: "FunctionDeclaration",
-    });
+    const functionInfo = registry.createFunctionInfo(
+      {
+        async: false,
+        generator: false,
+        id: identifier("testFun"),
+        params: [],
+        type: "FunctionDeclaration",
+      },
+      { path: "test.js", lineno: 42 },
+    );
 
     expect(functionInfo).toStrictEqual<registry.FunctionInfo>({
       async: false,
       generator: false,
       id: "testFun",
       params: [],
-      location: undefined,
+      location: { path: "test.js", lineno: 42 },
       static: true,
+      klassOrPkg: "test",
     });
   });
 });
@@ -52,7 +56,7 @@ describe(registry.createMethodInfo, () => {
       generator: false,
       params: [],
       id: "testMethod",
-      klass: "TestClass",
+      klassOrPkg: "TestClass",
       location: undefined,
       static: false,
     });

--- a/src/classMap.ts
+++ b/src/classMap.ts
@@ -22,10 +22,7 @@ export function makeClassMap(funs: Iterable<FunctionInfo>): AppMap.ClassMap {
       pkg = pkgs.pop()!;
       [tree, classes] = tree[pkg] ||= [{}, {}];
     }
-    // AppMap spec requires functions to always belong to a class.
-    // Free functions are common in JavaScript, so let's
-    // pretend they belong to a class with the same name as the package.
-    (classes[fun.klass ?? pkg] ||= []).push(fun);
+    (classes[fun.klassOrPkg] ||= []).push(fun);
   }
 
   let result = makeTree(root);

--- a/src/event.ts
+++ b/src/event.ts
@@ -19,7 +19,7 @@ export function makeCallEvent(
     static: !thisArg,
     receiver: optParameter(thisArg),
     parameters: resolveParameters(args, fun),
-    defined_class: fun.klass ?? "",
+    defined_class: fun.klassOrPkg,
     ...fun.location,
   });
 }

--- a/src/hooks/instrument.ts
+++ b/src/hooks/instrument.ts
@@ -40,7 +40,7 @@ export function transform(program: ESTree.Program, sourceMap?: SourceMapConsumer
       if (!hasIdentifier(fun)) return;
 
       const location = locate(fun);
-      if (sourceMap && !location) return; // don't instrument generated code
+      if (!location) return; // don't instrument generated code
 
       fun.body = wrapWithRecord(fun, createFunctionInfo(fun, location), false);
     },
@@ -53,7 +53,7 @@ export function transform(program: ESTree.Program, sourceMap?: SourceMapConsumer
       if (!klass) return;
 
       const location = locate(method);
-      if (sourceMap && !location) return; // don't instrument generated code
+      if (!location) return; // don't instrument generated code
 
       method.value.body = wrapWithRecord(
         { ...method.value },

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -10,17 +10,14 @@ import transform, { findHook } from "./transform";
 export const load: NodeLoaderHooksAPI2["load"] = async function load(url, context, defaultLoad) {
   const urlObj = new URL(url);
 
-  // With a custom loader, in node 18, extensionless files (typically used
+  // With a custom loader, in some node versions, extensionless files (typically used
   // as main entry points inside bin folders) are trated as ESM rather than
   // CommonJS modules. This leads to TypeError [ERR_UNKNOWN_FILE_EXTENSION].
   // To fix this, we give the context.format hint to defaultLoad if we decide
   // that the file is a CommonJS module.
-  const [major] = process.versions.node.split(".").map(Number);
-  if (major == 18) {
-    const ext = path.extname(urlObj.pathname).slice(1);
-    if (ext == "" && urlObj.protocol == "file:" && targetPackage?.type != "module") {
-      context.format = "commonjs";
-    }
+  const ext = path.extname(urlObj.pathname).slice(1);
+  if (ext == "" && urlObj.protocol == "file:" && targetPackage?.type != "module") {
+    context.format = "commonjs";
   }
 
   const hook = findHook(urlObj);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -26,7 +26,7 @@ export function createFunctionInfo(
     async,
     generator,
     id: id.name,
-    params,
+    params: params.map(stripLocation),
     location,
     static: true,
   };
@@ -46,10 +46,16 @@ export function createMethodInfo(
     async,
     generator,
     id: key.name,
-    params,
+    params: params.map(stripLocation),
     static: method.static,
     klass: klass.id.name,
     location,
   };
   return info;
+}
+
+function stripLocation(value: ESTree.Parameter): ESTree.Parameter {
+  const result = { ...value };
+  delete result.loc;
+  return result;
 }

--- a/test/__snapshots__/express.test.ts.snap
+++ b/test/__snapshots__/express.test.ts.snap
@@ -38,7 +38,7 @@ exports[`mapping Express.js requests 1`] = `
         "thread_id": 0,
       },
       {
-        "defined_class": "",
+        "defined_class": "index",
         "event": "call",
         "id": 2,
         "lineno": 21,
@@ -244,7 +244,7 @@ exports[`mapping Express.js requests 1`] = `
         "thread_id": 0,
       },
       {
-        "defined_class": "",
+        "defined_class": "index",
         "event": "call",
         "id": 2,
         "lineno": 25,
@@ -444,7 +444,7 @@ exports[`mapping Express.js requests 1`] = `
         "thread_id": 0,
       },
       {
-        "defined_class": "",
+        "defined_class": "index",
         "event": "call",
         "id": 2,
         "lineno": 29,

--- a/test/__snapshots__/httpClient.test.ts.snap
+++ b/test/__snapshots__/httpClient.test.ts.snap
@@ -24,7 +24,7 @@ exports[`mapping a Jest test 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "test",
       "event": "call",
       "id": 1,
       "lineno": 4,
@@ -103,7 +103,7 @@ exports[`mapping http client requests 1`] = `
   },
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 19,
@@ -271,7 +271,7 @@ exports[`mapping mocked http client requests 1`] = `
   },
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 39,
@@ -289,7 +289,7 @@ exports[`mapping mocked http client requests 1`] = `
       "thread_id": 0,
     },
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 3,
       "lineno": 19,

--- a/test/__snapshots__/jest.test.ts.snap
+++ b/test/__snapshots__/jest.test.ts.snap
@@ -25,7 +25,7 @@ exports[`mapping Jest tests 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "test",
         "event": "call",
         "id": 1,
         "lineno": 18,
@@ -98,7 +98,7 @@ exports[`mapping Jest tests 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "test",
         "event": "call",
         "id": 1,
         "lineno": 22,
@@ -176,7 +176,7 @@ Add a timeout value to this test to increase the timeout, if this is a long-runn
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 1,
@@ -260,7 +260,7 @@ Received: [31m3[39m",
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 1,

--- a/test/__snapshots__/mocha.test.ts.snap
+++ b/test/__snapshots__/mocha.test.ts.snap
@@ -25,7 +25,7 @@ exports[`mapping Mocha tests 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "test",
         "event": "call",
         "id": 1,
         "lineno": 18,
@@ -98,7 +98,7 @@ exports[`mapping Mocha tests 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 5,
@@ -179,7 +179,7 @@ exports[`mapping Mocha tests 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 1,

--- a/test/__snapshots__/mysql.test.ts.snap
+++ b/test/__snapshots__/mysql.test.ts.snap
@@ -38,7 +38,7 @@ exports[`mapping MySQL tests 1`] = `
   },
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 17,

--- a/test/__snapshots__/postgres.test.ts.snap
+++ b/test/__snapshots__/postgres.test.ts.snap
@@ -24,7 +24,7 @@ exports[`mapping PostgreSQL tests 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 4,

--- a/test/__snapshots__/simple.test.ts.snap
+++ b/test/__snapshots__/simple.test.ts.snap
@@ -24,7 +24,7 @@ exports[`finish signal is handled 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "server",
       "event": "call",
       "id": 1,
       "lineno": 1,
@@ -88,7 +88,7 @@ exports[`forwarding signals to the child 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "daemon",
       "event": "call",
       "id": 1,
       "lineno": 3,
@@ -152,7 +152,7 @@ exports[`mapping a custom Error class with a message property 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "inspect",
       "event": "call",
       "id": 1,
       "lineno": 5,
@@ -253,7 +253,7 @@ exports[`mapping a simple script 1`] = `
   },
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 17,
@@ -278,7 +278,7 @@ exports[`mapping a simple script 1`] = `
       "thread_id": 0,
     },
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 3,
       "lineno": 4,
@@ -306,7 +306,7 @@ exports[`mapping a simple script 1`] = `
       "thread_id": 0,
     },
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 5,
       "lineno": 4,
@@ -334,7 +334,7 @@ exports[`mapping a simple script 1`] = `
       "thread_id": 0,
     },
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 7,
       "lineno": 8,
@@ -357,7 +357,7 @@ exports[`mapping a simple script 1`] = `
       "thread_id": 0,
     },
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 9,
       "lineno": 13,
@@ -426,7 +426,7 @@ exports[`mapping an extensionless CommonJS file 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "extensionless",
       "event": "call",
       "id": 1,
       "lineno": 1,
@@ -490,7 +490,7 @@ exports[`mapping an mjs script 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 1,
@@ -554,7 +554,7 @@ exports[`mapping generator functions 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "generator",
       "event": "call",
       "id": 1,
       "lineno": 1,

--- a/test/__snapshots__/sqlite.test.ts.snap
+++ b/test/__snapshots__/sqlite.test.ts.snap
@@ -38,7 +38,7 @@ exports[`mapping Sqlite tests 1`] = `
   },
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 13,

--- a/test/__snapshots__/typescript.test.ts.snap
+++ b/test/__snapshots__/typescript.test.ts.snap
@@ -24,7 +24,7 @@ exports[`mapping a simple script 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 3,
@@ -98,7 +98,7 @@ exports[`mapping an mts script 1`] = `
   ],
   "events": [
     {
-      "defined_class": "",
+      "defined_class": "index",
       "event": "call",
       "id": 1,
       "lineno": 1,

--- a/test/__snapshots__/vitest.test.ts.snap
+++ b/test/__snapshots__/vitest.test.ts.snap
@@ -25,7 +25,7 @@ exports[`mapping vitest run  1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 1,
@@ -92,7 +92,7 @@ exports[`mapping vitest run  1`] = `
                 "type": "function",
               },
             ],
-            "name": "sum",
+            "name": "sum.test",
             "type": "class",
           },
         ],
@@ -102,7 +102,7 @@ exports[`mapping vitest run  1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "sum.test",
         "event": "call",
         "id": 1,
         "lineno": 14,
@@ -175,7 +175,7 @@ exports[`mapping vitest run  1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 9,
@@ -252,7 +252,7 @@ exports[`mapping vitest run  1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 9,
@@ -333,7 +333,7 @@ exports[`mapping vitest run  1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 5,
@@ -415,7 +415,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 1,
@@ -482,7 +482,7 @@ exports[`mapping vitest run --no-threads 1`] = `
                 "type": "function",
               },
             ],
-            "name": "sum",
+            "name": "sum.test",
             "type": "class",
           },
         ],
@@ -492,7 +492,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "sum.test",
         "event": "call",
         "id": 1,
         "lineno": 14,
@@ -565,7 +565,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 9,
@@ -642,7 +642,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 9,
@@ -723,7 +723,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 5,
@@ -805,7 +805,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 1,
@@ -872,7 +872,7 @@ exports[`mapping vitest run --single-thread 1`] = `
                 "type": "function",
               },
             ],
-            "name": "sum",
+            "name": "sum.test",
             "type": "class",
           },
         ],
@@ -882,7 +882,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "sum.test",
         "event": "call",
         "id": 1,
         "lineno": 14,
@@ -955,7 +955,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 9,
@@ -1032,7 +1032,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 9,
@@ -1113,7 +1113,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     ],
     "events": [
       {
-        "defined_class": "",
+        "defined_class": "calc",
         "event": "call",
         "id": 1,
         "lineno": 5,


### PR DESCRIPTION
Even though they don't have a defining class, appmap tools depend on this field being non-empty. Do the same trick as in classmap and fill it with package name.