### PR TITLE
fix: Double sql recording in PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,20 @@ jobs:
       matrix:
         node-version: [18, 20, 21]
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -23,6 +37,8 @@ jobs:
           node-version: ${{matrix.node-version}}
       - run: yarn
       - run: yarn test
+        env:
+          POSTGRES_URL: postgres://postgres:postgres@localhost:5432
 
   release:
     runs-on: ubuntu-latest

--- a/src/hooks/pg.ts
+++ b/src/hooks/pg.ts
@@ -6,8 +6,7 @@ import { getTime } from "../util/getTime";
 export default function pgHook(mod: typeof pg) {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   mod.Client.prototype.query = createQueryProxy(mod.Client.prototype.query);
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  mod.Pool.prototype.query = createQueryProxy(mod.Pool.prototype.query);
+  // No need to proxy Pool.query because it calls Client.query internally
   return mod;
 }
 

--- a/test/__snapshots__/postgres.test.ts.snap
+++ b/test/__snapshots__/postgres.test.ts.snap
@@ -8,7 +8,7 @@ exports[`mapping PostgreSQL tests 1`] = `
         {
           "children": [
             {
-              "location": "./index.js:4",
+              "location": "./index.js:6",
               "name": "main",
               "static": true,
               "type": "function",
@@ -22,12 +22,76 @@ exports[`mapping PostgreSQL tests 1`] = `
       "type": "package",
     },
   ],
+  "eventUpdates": {
+    "2": {
+      "elapsed": 31.337,
+      "event": "return",
+      "id": 2,
+      "parent_id": 1,
+      "return_value": {
+        "class": "Promise",
+        "object_id": 1,
+        "value": "Promise { undefined }",
+      },
+      "thread_id": 0,
+    },
+    "4": {
+      "elapsed": 31.337,
+      "event": "return",
+      "id": 4,
+      "parent_id": 3,
+      "return_value": {
+        "class": "Promise",
+        "object_id": 2,
+        "value": "Promise {
+  Result {
+    command: 'SELECT',
+    rowCount: 1,
+    oid: null,
+    rows: [Array],
+    fields: [Array],
+    _parsers: [Array],
+    _types: [TypeOverrides],
+    RowCtor: null,
+    rowAsArray: false,
+    _prebuiltEmptyResultObject: [Object]
+  }
+}",
+      },
+      "thread_id": 0,
+    },
+    "8": {
+      "elapsed": 31.337,
+      "event": "return",
+      "id": 8,
+      "parent_id": 7,
+      "return_value": {
+        "class": "Promise",
+        "object_id": 3,
+        "value": "Promise {
+  Result {
+    command: 'SELECT',
+    rowCount: 1,
+    oid: null,
+    rows: [Array],
+    fields: [Array],
+    _parsers: [Array],
+    _types: [TypeOverrides],
+    RowCtor: null,
+    rowAsArray: false,
+    _prebuiltEmptyResultObject: [Object]
+  }
+}",
+      },
+      "thread_id": 0,
+    },
+  },
   "events": [
     {
       "defined_class": "index",
       "event": "call",
       "id": 1,
-      "lineno": 4,
+      "lineno": 6,
       "method_id": "main",
       "parameters": [],
       "path": "./index.js",
@@ -35,19 +99,10 @@ exports[`mapping PostgreSQL tests 1`] = `
       "thread_id": 0,
     },
     {
-      "event": "call",
-      "id": 2,
-      "sql_query": {
-        "database_type": "postgres",
-        "sql": "select * from customer where id = 1001",
-      },
-      "thread_id": 0,
-    },
-    {
       "elapsed": 31.337,
       "event": "return",
-      "id": 3,
-      "parent_id": 2,
+      "id": 2,
+      "parent_id": 1,
       "return_value": {
         "class": "Promise",
         "object_id": 1,
@@ -57,18 +112,18 @@ exports[`mapping PostgreSQL tests 1`] = `
     },
     {
       "event": "call",
-      "id": 4,
+      "id": 3,
       "sql_query": {
         "database_type": "postgres",
-        "sql": "select * from invoice where customer_id = 1001",
+        "sql": "select * from pg_config where name = 'BINDIR'",
       },
       "thread_id": 0,
     },
     {
       "elapsed": 31.337,
       "event": "return",
-      "id": 5,
-      "parent_id": 4,
+      "id": 4,
+      "parent_id": 3,
       "return_value": {
         "class": "Promise",
         "object_id": 2,
@@ -78,22 +133,26 @@ exports[`mapping PostgreSQL tests 1`] = `
     },
     {
       "event": "call",
-      "id": 6,
+      "id": 5,
       "sql_query": {
         "database_type": "postgres",
-        "sql": "select * from user where id = $1",
+        "sql": "select * from pg_config where name = 'DOCDIR'",
       },
       "thread_id": 0,
     },
     {
       "elapsed": 31.337,
       "event": "return",
+      "id": 6,
+      "parent_id": 5,
+      "thread_id": 0,
+    },
+    {
+      "event": "call",
       "id": 7,
-      "parent_id": 6,
-      "return_value": {
-        "class": "Promise",
-        "object_id": 3,
-        "value": "Promise { <pending> }",
+      "sql_query": {
+        "database_type": "postgres",
+        "sql": "select * from pg_config where name = $1",
       },
       "thread_id": 0,
     },
@@ -101,7 +160,12 @@ exports[`mapping PostgreSQL tests 1`] = `
       "elapsed": 31.337,
       "event": "return",
       "id": 8,
-      "parent_id": 1,
+      "parent_id": 7,
+      "return_value": {
+        "class": "Promise",
+        "object_id": 3,
+        "value": "Promise { <pending> }",
+      },
       "thread_id": 0,
     },
   ],

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -1,4 +1,13 @@
-import { integrationTest, readAppmap, runAppmapNode } from "./helpers";
+import { join } from "node:path";
+
+import { readAppmap, runAppmapNode, testDir } from "./helpers";
+
+testDir(join(__dirname, "postgres"));
+
+// To run these tests, set POSTGRES_URL to a url such as
+// socket:/var/run/postgresql or
+// postgres://postgres.host.example
+const integrationTest = process.env.POSTGRES_URL ? test : test.skip;
 
 integrationTest("mapping PostgreSQL tests", () => {
   expect(runAppmapNode("index.js").status).toBe(0);

--- a/test/postgres/index.js
+++ b/test/postgres/index.js
@@ -5,11 +5,13 @@ function main() {
   // Since we don't use a real database and we don't/can't connect to one,
   // query methods will thow exceptions. We discard the exceptions because
   // we are only testing if the query methods are patched for recording.
+  // We can't record Pool.query without a real database because it uses
+  // Client.query internally and it will throw before calling it in this case.
 
   new pg.Client().query("select * from customer where id = 1001").catch(() => {
     /* empty */
   });
-  new pg.Pool().query("select * from invoice where customer_id = 1001").catch(() => {
+  new pg.Client().query("select * from invoice where customer_id = 1001").catch(() => {
     /* empty */
   });
 


### PR DESCRIPTION
Fixes #64.

Removed proxying Pool.query method because it uses Client.query internally.