### PR TITLE
fix: Handle rejected promises

### DIFF
--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -66,7 +66,7 @@ describe(recorder.fixReturnEventIfPromiseResult, () => {
     expect(Recording.prototype.fixup).toBeCalledWith({
       ...returnEvent,
       return_value: {
-        class: "Promise",
+        class: "Promise<String>",
         value: "Promise { 'resolved' }",
         object_id: 1,
       },

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -70,11 +70,17 @@ function propertiesSchema(
 }
 
 let nextId = 1;
-const objectIds = new WeakMap<object, number>();
+let objectIds = new WeakMap<object, number>();
 
 export function objectId(object: object | null): number {
   if (object === null) return 0;
   const id = objectIds.get(object) ?? nextId++;
   if (!objectIds.has(object)) objectIds.set(object, id);
   return id;
+}
+
+// for testing purposes
+export function resetObjectIds() {
+  nextId = 1;
+  objectIds = new WeakMap();
 }

--- a/test/__snapshots__/httpClient.test.ts.snap
+++ b/test/__snapshots__/httpClient.test.ts.snap
@@ -94,7 +94,7 @@ exports[`mapping http client requests 1`] = `
       "id": 2,
       "parent_id": 1,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<undefined>",
         "object_id": 1,
         "value": "Promise { undefined }",
       },
@@ -262,7 +262,7 @@ exports[`mapping mocked http client requests 1`] = `
       "id": 2,
       "parent_id": 1,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<undefined>",
         "object_id": 1,
         "value": "Promise { undefined }",
       },
@@ -274,7 +274,7 @@ exports[`mapping mocked http client requests 1`] = `
       "id": 4,
       "parent_id": 3,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<undefined>",
         "object_id": 2,
         "value": "Promise { undefined }",
       },

--- a/test/__snapshots__/mysql.test.ts.snap
+++ b/test/__snapshots__/mysql.test.ts.snap
@@ -29,7 +29,7 @@ exports[`mapping MySQL tests 1`] = `
       "id": 3,
       "parent_id": 1,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<undefined>",
         "object_id": 1,
         "value": "Promise { undefined }",
       },

--- a/test/__snapshots__/postgres.test.ts.snap
+++ b/test/__snapshots__/postgres.test.ts.snap
@@ -29,7 +29,7 @@ exports[`mapping PostgreSQL tests 1`] = `
       "id": 2,
       "parent_id": 1,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<undefined>",
         "object_id": 1,
         "value": "Promise { undefined }",
       },
@@ -41,7 +41,7 @@ exports[`mapping PostgreSQL tests 1`] = `
       "id": 4,
       "parent_id": 3,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<Result>",
         "object_id": 2,
         "value": "Promise {
   Result {
@@ -66,7 +66,7 @@ exports[`mapping PostgreSQL tests 1`] = `
       "id": 8,
       "parent_id": 7,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<Result>",
         "object_id": 3,
         "value": "Promise {
   Result {

--- a/test/__snapshots__/simple.test.ts.snap
+++ b/test/__snapshots__/simple.test.ts.snap
@@ -263,7 +263,7 @@ exports[`mapping a simple script 1`] = `
       "id": 8,
       "parent_id": 7,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<String>",
         "object_id": 2,
         "value": "Promise { 'promised return' }",
       },

--- a/test/__snapshots__/simple.test.ts.snap
+++ b/test/__snapshots__/simple.test.ts.snap
@@ -205,13 +205,13 @@ exports[`mapping a simple script 1`] = `
         {
           "children": [
             {
-              "location": "./index.js:13",
+              "location": "./index.js:14",
               "name": "immediatePromise",
               "static": true,
               "type": "function",
             },
             {
-              "location": "./index.js:17",
+              "location": "./index.js:18",
               "name": "throws",
               "static": true,
               "type": "function",
@@ -238,6 +238,25 @@ exports[`mapping a simple script 1`] = `
     },
   ],
   "eventUpdates": {
+    "10": {
+      "elapsed": 31.337,
+      "event": "return",
+      "exceptions": [
+        {
+          "class": "Error",
+          "message": "throws intentionally",
+          "object_id": 5,
+        },
+      ],
+      "id": 10,
+      "parent_id": 9,
+      "return_value": {
+        "class": "Promise",
+        "object_id": 3,
+        "value": "Promise { <rejected> }",
+      },
+      "thread_id": 0,
+    },
     "8": {
       "elapsed": 31.337,
       "event": "return",
@@ -256,7 +275,7 @@ exports[`mapping a simple script 1`] = `
       "defined_class": "index",
       "event": "call",
       "id": 1,
-      "lineno": 17,
+      "lineno": 18,
       "method_id": "throws",
       "parameters": [],
       "path": "./index.js",
@@ -360,9 +379,15 @@ exports[`mapping a simple script 1`] = `
       "defined_class": "index",
       "event": "call",
       "id": 9,
-      "lineno": 13,
-      "method_id": "immediatePromise",
-      "parameters": [],
+      "lineno": 8,
+      "method_id": "promised",
+      "parameters": [
+        {
+          "class": "Boolean",
+          "name": "ok",
+          "value": "false",
+        },
+      ],
       "path": "./index.js",
       "static": true,
       "thread_id": 0,
@@ -375,8 +400,56 @@ exports[`mapping a simple script 1`] = `
       "return_value": {
         "class": "Promise",
         "object_id": 3,
+        "value": "Promise { <pending> }",
+      },
+      "thread_id": 0,
+    },
+    {
+      "defined_class": "index",
+      "event": "call",
+      "id": 11,
+      "lineno": 14,
+      "method_id": "immediatePromise",
+      "parameters": [],
+      "path": "./index.js",
+      "static": true,
+      "thread_id": 0,
+    },
+    {
+      "elapsed": 31.337,
+      "event": "return",
+      "id": 12,
+      "parent_id": 11,
+      "return_value": {
+        "class": "Promise",
+        "object_id": 4,
         "value": "Promise { 'immediate' }",
       },
+      "thread_id": 0,
+    },
+    {
+      "defined_class": "index",
+      "event": "call",
+      "id": 13,
+      "lineno": 18,
+      "method_id": "throws",
+      "parameters": [],
+      "path": "./index.js",
+      "static": true,
+      "thread_id": 0,
+    },
+    {
+      "elapsed": 31.337,
+      "event": "return",
+      "exceptions": [
+        {
+          "class": "Error",
+          "message": "throws intentionally",
+          "object_id": 5,
+        },
+      ],
+      "id": 14,
+      "parent_id": 13,
       "thread_id": 0,
     },
   ],

--- a/test/__snapshots__/sqlite.test.ts.snap
+++ b/test/__snapshots__/sqlite.test.ts.snap
@@ -29,7 +29,7 @@ exports[`mapping Sqlite tests 1`] = `
       "id": 3,
       "parent_id": 1,
       "return_value": {
-        "class": "Promise",
+        "class": "Promise<undefined>",
         "object_id": 1,
         "value": "Promise { undefined }",
       },

--- a/test/simple/index.js
+++ b/test/simple/index.js
@@ -5,8 +5,9 @@ function foo(x) {
   return x * 2;
 }
 
-async function promised() {
-  await setTimeout(100);
+async function promised(ok = true) {
+  await setTimeout(10);
+  if (!ok) throws();
   return "promised return";
 }
 
@@ -28,4 +29,5 @@ try {
 
 console.log(foo(42));
 promised().then(console.log);
+promised(false).catch(console.log);
 immediatePromise().then(console.log);


### PR DESCRIPTION
Note an event update for a return event for a rejected promise will contain both `exception` and `return_value` fields to disambiguate with the case when the returning function throws an exception directly.