### PR TITLE
Remove typescript runtime dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           node-version: ${{matrix.node-version}}
       - run: yarn
+      - run: node test/smoketest.mjs
       - run: yarn test
         env:
           POSTGRES_URL: postgres://postgres:postgres@localhost:5432

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "convert-source-map": "^2.0.0",
     "meriyah": "^4.3.7",
     "source-map-js": "^1.0.2",
+    "strip-json-comments": "^3",
     "yaml": "^2.3.4"
   },
   "workspaces": [

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,7 +4,7 @@ import { accessSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { kill, pid } from "node:process";
 
-import { parseConfigFileTextToJson } from "typescript";
+import stripJsonComments from "strip-json-comments";
 import YAML from "yaml";
 
 import config from "./config";
@@ -74,7 +74,7 @@ function isTsEsmLoaderNeeded(cmd: string, args: string[]) {
     const tsConfigSource = readTsConfigUp(config.root);
     if (tsConfigSource == null) return false;
 
-    const tsConfig: unknown = parseConfigFileTextToJson("", tsConfigSource).config;
+    const tsConfig: unknown = JSON.parse(stripJsonComments(tsConfigSource));
     // Check if ts-node is configured and has esm set to true
     return (
       tsConfig != null &&

--- a/test/smoketest.mjs
+++ b/test/smoketest.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { chdir } from "node:process";
+
+import glob from "fast-glob";
+import tmp from "tmp";
+
+/* Smoke test script, meant to catch problems with package build.
+ * Creates a basic barebones javascript package. Then, packages up
+ * appmap-node and installs it into the package.
+ * Finally, uses appmap-node to run the package and verifies that
+ * it doesn't crash and produces an AppMap. */
+
+// Create a temporary directory to work in.
+const tmpDir = tmp.dirSync({ unsafeCleanup: true }).name;
+
+// Package up the appmap-node package.
+runCommand("yarn", "pack", "-o", join(tmpDir, "appmap-node.tgz"));
+
+chdir(tmpDir);
+runCommand("npm", "init", "-y");
+runCommand("npm", "install", join(tmpDir, "appmap-node.tgz"));
+
+writeFileSync(
+  "index.js",
+  `
+function main() {
+  console.log("Hello world!");
+}
+main();
+`,
+);
+
+runCommand("npm", "exec", "appmap-node", "index.js");
+
+// verify that appmap has been created
+const files = glob.globSync("tmp/**/*.appmap.json");
+assert(files.length === 1);
+
+function runCommand(command, ...args) {
+  const { status } = spawnSync(command, args, { stdio: "inherit" });
+  assert(status === 0);
+}

--- a/test/sqlite/index.js
+++ b/test/sqlite/index.js
@@ -69,7 +69,7 @@ async function main() {
   // because promisify already provides the completion callback to resolve the promise.
   // We test this case with no completion callback here wtihout promisifying them.
   db.run("SELECT 'Database.run without a completion callback'");
-  await setTimeout(10); // to serialize the appmap
+  await setTimeout(50); // to serialize the appmap
   db.prepare("SELECT 'Statement.run without a completion callback'").run().finalize();
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,6 +2679,7 @@ __metadata:
     prettier: ^3.0.2
     semantic-release: ^22.0.5
     source-map-js: ^1.0.2
+    strip-json-comments: ^3
     tmp: ^0.2.1
     ts-node: ^10.9.1
     type-fest: ^4.3.2
@@ -9340,7 +9341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:3.1.1, strip-json-comments@npm:^3.1.1":
+"strip-json-comments@npm:3.1.1, strip-json-comments@npm:^3, strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443


### PR DESCRIPTION
This dependency was inadvertently added, but not declared in package.json, leading to problems when run without typescript available. Since it was only used to parse tsconfig.json, it could be replaced by strip-json-comments.