### PR TITLE
feat: Replace spaces in filenames with underscores

### DIFF
--- a/src/Recording.ts
+++ b/src/Recording.ts
@@ -218,5 +218,6 @@ function makeAppMapFilename(name: string): string {
 }
 
 function quotePathSegment(value: string): string {
-  return value.replaceAll(/[/\\]/g, "-");
+  // note replacing spaces isn't strictly necessary improves UX
+  return value.replaceAll(/[/\\]/g, "-").replaceAll(" ", "_");
 }

--- a/test/__snapshots__/httpServer.test.ts.snap
+++ b/test/__snapshots__/httpServer.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`mapping Express.js requests 1`] = `
 {
-  "./tmp/appmap/requests/<timestamp 0> -.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 0>_-.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -109,7 +109,7 @@ exports[`mapping Express.js requests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/requests/<timestamp 1> -nonexistent.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 1>_-nonexistent.appmap.json": {
     "classMap": [],
     "events": [
       {
@@ -163,7 +163,7 @@ exports[`mapping Express.js requests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/requests/<timestamp 2> -api-foo.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 2>_-api-foo.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -334,7 +334,7 @@ exports[`mapping Express.js requests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/requests/<timestamp 3> -api-bar.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 3>_-api-bar.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -1106,7 +1106,7 @@ exports[`mapping Express.js requests with remote recording 1`] = `
 
 exports[`mapping node:http requests 1`] = `
 {
-  "./tmp/appmap/requests/<timestamp 0> -.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 0>_-.appmap.json": {
     "classMap": [],
     "events": [
       {
@@ -1154,7 +1154,7 @@ exports[`mapping node:http requests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/requests/<timestamp 1> -nonexistent.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 1>_-nonexistent.appmap.json": {
     "classMap": [],
     "events": [
       {
@@ -1202,7 +1202,7 @@ exports[`mapping node:http requests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/requests/<timestamp 2> -api-foo.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 2>_-api-foo.appmap.json": {
     "classMap": [],
     "events": [
       {
@@ -1262,7 +1262,7 @@ exports[`mapping node:http requests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/requests/<timestamp 3> -api-bar.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 3>_-api-bar.appmap.json": {
     "classMap": [],
     "events": [
       {

--- a/test/__snapshots__/jest.test.ts.snap
+++ b/test/__snapshots__/jest.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`mapping Jest tests 1`] = `
 {
-  "./tmp/appmap/jest/exception handling/intentionally throws.appmap.json": {
+  "./tmp/appmap/jest/exception_handling/intentionally_throws.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -75,7 +75,7 @@ exports[`mapping Jest tests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/jest/exception handling/times out.appmap.json": {
+  "./tmp/appmap/jest/exception_handling/times_out.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -153,7 +153,7 @@ Add a timeout value to this test to increase the timeout, if this is a long-runn
     },
     "version": "1.12",
   },
-  "./tmp/appmap/jest/sub/subtracts numbers correctly.appmap.json": {
+  "./tmp/appmap/jest/sub/subtracts_numbers_correctly.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -237,7 +237,7 @@ Received: [31m3[39m",
     },
     "version": "1.12",
   },
-  "./tmp/appmap/jest/sum/sums numbers correctly.appmap.json": {
+  "./tmp/appmap/jest/sum/sums_numbers_correctly.appmap.json": {
     "classMap": [
       {
         "children": [

--- a/test/__snapshots__/mocha.test.ts.snap
+++ b/test/__snapshots__/mocha.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`mapping Mocha tests 1`] = `
 {
-  "./tmp/appmap/mocha/exception handling/intentionally throws.appmap.json": {
+  "./tmp/appmap/mocha/exception_handling/intentionally_throws.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -75,7 +75,7 @@ exports[`mapping Mocha tests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/mocha/multiply/calculates power correctly.appmap.json": {
+  "./tmp/appmap/mocha/multiply/calculates_power_correctly.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -156,7 +156,7 @@ exports[`mapping Mocha tests 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/mocha/multiply/multiplies numbers correctly.appmap.json": {
+  "./tmp/appmap/mocha/multiply/multiplies_numbers_correctly.appmap.json": {
     "classMap": [
       {
         "children": [

--- a/test/__snapshots__/next.test.ts.snap
+++ b/test/__snapshots__/next.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`mapping a Next.js appmap 1`] = `
 {
-  "./tmp/appmap/requests/<timestamp 0> -hello.appmap.json": {
+  "./tmp/appmap/requests/<timestamp 0>_-hello.appmap.json": {
     "classMap": [
       {
         "children": [

--- a/test/__snapshots__/vitest.test.ts.snap
+++ b/test/__snapshots__/vitest.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`mapping vitest run  1`] = `
 {
-  "./tmp/appmap/vitest/adds 1 + 2 to equal 3.appmap.json": {
+  "./tmp/appmap/vitest/adds_1_+_2_to_equal_3.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -79,7 +79,7 @@ exports[`mapping vitest run  1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/exception handling.appmap.json": {
+  "./tmp/appmap/vitest/exception_handling.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -152,7 +152,7 @@ exports[`mapping vitest run  1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/multiplies 0 by 3 to equal 0.appmap.json": {
+  "./tmp/appmap/vitest/multiplies_0_by_3_to_equal_0.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -229,7 +229,7 @@ exports[`mapping vitest run  1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/multiplies 5 by 4 to equal 20.appmap.json": {
+  "./tmp/appmap/vitest/multiplies_5_by_4_to_equal_20.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -310,7 +310,7 @@ exports[`mapping vitest run  1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/subtracts 9 - 2 to equal 7.appmap.json": {
+  "./tmp/appmap/vitest/subtracts_9_-_2_to_equal_7.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -392,7 +392,7 @@ exports[`mapping vitest run  1`] = `
 
 exports[`mapping vitest run --no-threads 1`] = `
 {
-  "./tmp/appmap/vitest/adds 1 + 2 to equal 3.appmap.json": {
+  "./tmp/appmap/vitest/adds_1_+_2_to_equal_3.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -469,7 +469,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/exception handling.appmap.json": {
+  "./tmp/appmap/vitest/exception_handling.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -542,7 +542,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/multiplies 0 by 3 to equal 0.appmap.json": {
+  "./tmp/appmap/vitest/multiplies_0_by_3_to_equal_0.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -619,7 +619,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/multiplies 5 by 4 to equal 20.appmap.json": {
+  "./tmp/appmap/vitest/multiplies_5_by_4_to_equal_20.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -700,7 +700,7 @@ exports[`mapping vitest run --no-threads 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/subtracts 9 - 2 to equal 7.appmap.json": {
+  "./tmp/appmap/vitest/subtracts_9_-_2_to_equal_7.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -782,7 +782,7 @@ exports[`mapping vitest run --no-threads 1`] = `
 
 exports[`mapping vitest run --single-thread 1`] = `
 {
-  "./tmp/appmap/vitest/adds 1 + 2 to equal 3.appmap.json": {
+  "./tmp/appmap/vitest/adds_1_+_2_to_equal_3.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -859,7 +859,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/exception handling.appmap.json": {
+  "./tmp/appmap/vitest/exception_handling.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -932,7 +932,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/multiplies 0 by 3 to equal 0.appmap.json": {
+  "./tmp/appmap/vitest/multiplies_0_by_3_to_equal_0.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -1009,7 +1009,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/multiplies 5 by 4 to equal 20.appmap.json": {
+  "./tmp/appmap/vitest/multiplies_5_by_4_to_equal_20.appmap.json": {
     "classMap": [
       {
         "children": [
@@ -1090,7 +1090,7 @@ exports[`mapping vitest run --single-thread 1`] = `
     },
     "version": "1.12",
   },
-  "./tmp/appmap/vitest/subtracts 9 - 2 to equal 7.appmap.json": {
+  "./tmp/appmap/vitest/subtracts_9_-_2_to_equal_7.appmap.json": {
     "classMap": [
       {
         "children": [


### PR DESCRIPTION
Note this isn't strictly necessary, but allows the paths to be handled more easily eg. with terminal applications making them clickable.

Fixes #94