### PR TITLE
fix: Stack overflow in circularly referenced parameter objects

### DIFF
--- a/src/__tests__/parameter.test.ts
+++ b/src/__tests__/parameter.test.ts
@@ -68,3 +68,22 @@ describe(objectId, () => {
     expect([objectId(arr), objectId(obj)]).toStrictEqual(ids);
   });
 });
+
+describe(parameter, () => {
+  it("transforms circular references", () => {
+    class Circular {
+      name?: string;
+      favorite?: Circular;
+      items?: Circular[];
+    }
+
+    const obj = new Object() as Circular;
+    obj.name = "Selfish";
+
+    obj.favorite = obj;
+    expect(parameter(obj).class).toBe("Object");
+
+    obj.items = [obj];
+    expect(parameter(obj).class).toBe("Object");
+  });
+});


### PR DESCRIPTION
Fixes #90. 

Fixes the reported "Maximum call stack size exceeded" problem in the issue, however there is at least one more problem in running cal.com with appmap-node.
