### PR TITLE
fix: Properly parse tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,9 +71,9 @@
     "acorn-walk": "^8.2.0",
     "astring": "^1.8.6",
     "chalk": "<5",
+    "json5": "^2.2.3",
     "meriyah": "^4.3.7",
     "source-map-js": "^1.0.2",
-    "strip-json-comments": "^3",
     "yaml": "^2.3.4"
   },
   "workspaces": [

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { kill, pid } from "node:process";
 import { pathToFileURL } from "node:url";
 
-import stripJsonComments from "strip-json-comments";
+import json5 from "json5";
 import YAML from "yaml";
 
 import config from "./config";
@@ -85,7 +85,7 @@ function isTsEsmLoaderNeeded(cmd: string, args: string[]) {
     const tsConfigSource = readTsConfigUp(config.root);
     if (tsConfigSource == null) return false;
 
-    const tsConfig: unknown = JSON.parse(stripJsonComments(tsConfigSource));
+    const tsConfig: unknown = json5.parse(tsConfigSource);
     // Check if ts-node is configured and has esm set to true
     return (
       tsConfig != null &&

--- a/test/typescript-esm/tsconfig.json
+++ b/test/typescript-esm/tsconfig.json
@@ -9,6 +9,6 @@
     "rootDir": "src" /* Specify the root folder within your source files. */,
     "outDir": "dist",
     "types": ["node"],
-    "sourceMap": true
+    "sourceMap": true, /* Trailing comma needs to be parsed correctly */
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2733,6 +2733,7 @@ __metadata:
     eslint-plugin-prettier: ^5.0.1
     fast-glob: ^3.3.1
     jest: ^29.6.2
+    json5: ^2.2.3
     meriyah: ^4.3.7
     next: ^14.0.4
     prettier: ^3.0.2
@@ -2740,7 +2741,6 @@ __metadata:
     react-dom: ^18
     semantic-release: ^22.0.5
     source-map-js: ^1.0.2
-    strip-json-comments: ^3
     tmp: ^0.2.1
     ts-node: ^10.9.1
     type-fest: ^4.3.2
@@ -6206,7 +6206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.2":
+"json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -9422,7 +9422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:3.1.1, strip-json-comments@npm:^3, strip-json-comments@npm:^3.1.1":
+"strip-json-comments@npm:3.1.1, strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443


### PR DESCRIPTION
Fixes #91

`tsconfig.json` cannot be parsed with `JSON.parse` properly. It can have trailing comma which is not legal in JSON. Use `typescript.readConfigFile` instead.