### PR TITLE
fix: Replace special characters in paths consistently on all platforms

### DIFF
--- a/src/Recording.ts
+++ b/src/Recording.ts
@@ -221,8 +221,7 @@ function makeAppMapFilename(name: string): string {
   return name + ".appmap.json";
 }
 
-const charsToQuote = process.platform == "win32" ? /[/\\:<>*"|?]/g : /[/\\]/g;
 function quotePathSegment(value: string): string {
-  // note replacing spaces isn't strictly necessary improves UX
-  return value.replaceAll(charsToQuote, "-").replaceAll(" ", "_");
+  // note replacing spaces isn't strictly necessary but improves UX
+  return value.replaceAll(/[/\\:<>*"|?]/g, "-").replaceAll(" ", "_");
 }


### PR DESCRIPTION
Even though some of the characters are technically legal on some platforms, they might still be inconvenient and inconsistent.

Fixes #134