### PR TITLE
fix: Check if recordings are still active after promise resolution and callbacks

### DIFF
--- a/src/hooks/http.ts
+++ b/src/hooks/http.ts
@@ -13,6 +13,7 @@ import {
   getActiveRecordings,
   getRemoteRecording,
   getRequestRecording,
+  isActive,
   startProcessRecording,
   startRemoteRecording,
   startRequestRecording,
@@ -135,6 +136,8 @@ function handleClientRequest(request: http.ClientRequest) {
 
         recordings.forEach((recording, idx) => {
           assert(response.statusCode != undefined);
+          if (!isActive(recording)) return;
+
           recording.httpClientResponse(
             clientRequestEvents[idx].id,
             elapsed,
@@ -286,6 +289,7 @@ function handleRequest(request: http.IncomingMessage, response: http.ServerRespo
     const returnValue = capture.createReturnValue(isJson);
 
     recordings.forEach((recording, idx) => {
+      if (!isActive(recording)) return;
       if (fixupEvent(request, requestEvents[idx])) recording.fixup(requestEvents[idx]);
 
       recording.httpResponse(

--- a/src/hooks/mongo.ts
+++ b/src/hooks/mongo.ts
@@ -3,7 +3,7 @@ import { inspect } from "node:util";
 import type mongodb from "mongodb";
 
 import { identifier } from "../generate";
-import { fixReturnEventsIfPromiseResult, getActiveRecordings } from "../recorder";
+import { fixReturnEventsIfPromiseResult, getActiveRecordings, isActive } from "../recorder";
 import { FunctionInfo } from "../registry";
 import { getTime } from "../util/getTime";
 import { setCustomInspect } from "../parameter";
@@ -113,12 +113,14 @@ function patchMethod<K extends MethodLikeKeys<mongodb.Collection>>(
 
         const elapsed = getTime() - startTime;
         if (err)
-          recordings.forEach((recording, idx) =>
-            recording.functionException(callEvents[idx].id, err, elapsed),
+          recordings.forEach(
+            (recording, idx) =>
+              isActive(recording) && recording.functionException(callEvents[idx].id, err, elapsed),
           );
         else
-          recordings.forEach((recording, idx) =>
-            recording.functionReturn(callEvents[idx].id, res, elapsed),
+          recordings.forEach(
+            (recording, idx) =>
+              isActive(recording) && recording.functionReturn(callEvents[idx].id, res, elapsed),
           );
 
         return callback(err, res) as unknown;

--- a/src/hooks/mysql.ts
+++ b/src/hooks/mysql.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 
 import type mysql from "mysql";
 
-import { getActiveRecordings } from "../recorder";
+import { getActiveRecordings, isActive } from "../recorder";
 import { getTime } from "../util/getTime";
 
 export default function mysqlHook(mod: typeof mysql) {
@@ -55,12 +55,15 @@ function createQueryProxy(query: mysql.QueryFunction) {
       const newCallback: mysql.queryCallback = (err, results, fields) => {
         const elapsed = getTime() - startTime;
         if (err)
-          recordings.forEach((recording, idx) =>
-            recording.functionException(callEvents[idx].id, err, elapsed),
+          recordings.forEach(
+            (recording, idx) =>
+              isActive(recording) && recording.functionException(callEvents[idx].id, err, elapsed),
           );
         else
-          recordings.forEach((recording, idx) =>
-            recording.functionReturn(callEvents[idx].id, undefined, elapsed),
+          recordings.forEach(
+            (recording, idx) =>
+              isActive(recording) &&
+              recording.functionReturn(callEvents[idx].id, undefined, elapsed),
           );
 
         originalCallback?.call(this, err, results, fields);

--- a/src/hooks/sqlite.ts
+++ b/src/hooks/sqlite.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type sqlite from "sqlite3";
 
-import { getActiveRecordings } from "../recorder";
+import { getActiveRecordings, isActive } from "../recorder";
 import { getTime } from "../util/getTime";
 
 type RecordingProxyTarget =
@@ -85,8 +85,10 @@ function createRecordingProxy<T extends RecordingProxyTarget>(
         const isError = args.length > 0 && args[0] != undefined;
         if (!isError) {
           const elapsed = getTime() - startTime;
-          recordings.forEach((recording, idx) =>
-            recording.functionReturn(callEvents[idx].id, undefined, elapsed),
+          recordings.forEach(
+            (recording, idx) =>
+              isActive(recording) &&
+              recording.functionReturn(callEvents[idx].id, undefined, elapsed),
           );
         }
         originalCompletionCallback?.apply(this, args);

--- a/test/jest.test.ts
+++ b/test/jest.test.ts
@@ -1,3 +1,5 @@
+import { format } from "node:util";
+
 import { integrationTest, readAppmaps, runAppmapNode, runAppmapNodeWithOptions } from "./helpers";
 
 integrationTest("mapping Jest tests", () => {
@@ -22,6 +24,11 @@ integrationTest("mapping Jest tests with process recording active", () => {
   expect(appmaps).toMatchSnapshot();
 
   const appmapsArray = Object.values(appmaps);
-  expect(appmapsArray.filter((a) => a.metadata?.recorder.type == "process").length).toEqual(1);
+
+  const processMaps = Object.entries(appmaps).filter(
+    ([, a]) => a.metadata?.recorder.type == "process",
+  );
+  if (processMaps.length != 1)
+    throw new Error(format("expected one process appmap, got: ", Object.fromEntries(processMaps)));
   expect(appmapsArray.filter((a) => a.metadata?.recorder.type == "tests").length).toEqual(5);
 });


### PR DESCRIPTION
There was an issue with some generated appmaps, which resulted in the error bellow in the VS Code AppMap viewer - the spinner kept spinning. 

The problem arose from the `parent_id` of certain event update objects (members of the `eventUpdates` array) not matching a call event in the same appmap. In some cases, an appmap had finished, and a new one had been created by the time a promise was resolved, leading to the creation of a fix-up event in the wrong appmap.

This fix verifies whether we are in the correct appmap and skips the fix-up process if not.

<img width="345" alt="image" src="https://github.com/getappmap/appmap-node/assets/98758224/ef77df3a-8633-403b-994f-85743f0b4ac6">

<img width="493" alt="image" src="https://github.com/getappmap/appmap-node/assets/98758224/a9624395-eb13-4bcc-b23d-841c3a483a59">
