### PR TITLE
feat: Add `language` to appmap.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can create `appmap.yml` config file; if not found, a default one will be cre
 ```yaml
 name: application-name  # from package.json by default
 appmap_dir: tmp/appmap
+language: javascript
 packages:
 - path: .  # paths to instrument, relative to appmap.yml location
   exclude:  # code to exclude from instrumentation

--- a/src/__tests__/__snapshots__/config.test.ts.snap
+++ b/src/__tests__/__snapshots__/config.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Config migrate does not update an existing config if the language field is already set 1`] = `
+"name: test-package
+language: ruby
+appmap_dir: appmap
+packages:
+  - path: .
+"
+`;
+
+exports[`Config migrate sets the language field in existing configs 1`] = `
+"name: test-package
+appmap_dir: appmap
+packages:
+  - path: .
+language: javascript
+"
+`;

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -33,6 +33,7 @@ describe(Config, () => {
       packages: new PackageMatcher("/test/app", [
         { path: ".", exclude: ["node_modules", ".yarn"] },
       ]),
+      language: "javascript",
     });
   });
 
@@ -41,6 +42,7 @@ describe(Config, () => {
       root: fixMacOsTmpPath(dir),
       relativeAppmapDir: "tmp/appmap",
       appName: basename(dir),
+      language: "javascript",
     });
   });
 
@@ -53,6 +55,7 @@ describe(Config, () => {
       root: fixMacOsTmpPath(dir),
       relativeAppmapDir: "tmp/appmap",
       appName: "test-package",
+      language: "javascript",
     });
   });
 
@@ -61,6 +64,7 @@ describe(Config, () => {
       "appmap.yml",
       YAML.stringify({
         name: "test-package",
+        language: "javascript",
         appmap_dir: "appmap",
         packages: [{ path: ".", exclude: ["excluded"] }, "../lib"],
       }),
@@ -71,6 +75,7 @@ describe(Config, () => {
     expect(new Config()).toMatchObject({
       root: fixMacOsTmpPath(dir),
       relativeAppmapDir: "appmap",
+      language: "javascript",
       appName: "test-package",
       packages: new PackageMatcher(fixMacOsTmpPath(dir), [
         { path: ".", exclude: ["excluded"] },
@@ -84,6 +89,7 @@ describe(Config, () => {
       "appmap.yml",
       YAML.stringify({
         name: "test-package",
+        language: "javascript",
         appmap_dir: "appmap",
         packages: [{ regexp: "foo", enabled: false }],
       }),
@@ -95,6 +101,7 @@ describe(Config, () => {
       root: fixMacOsTmpPath(dir),
       relativeAppmapDir: "appmap",
       appName: "test-package",
+      language: "javascript",
       packages: new PackageMatcher(fixMacOsTmpPath(dir), [
         { path: ".", exclude: ["node_modules", ".yarn"] },
       ]),
@@ -110,6 +117,38 @@ describe(Config, () => {
     );
 
     expect(readFileSync("appmap.yml").toString()).toEqual(malformedAppMapFileContent);
+  });
+
+  describe("migrate", () => {
+    it("sets the language field in existing configs", () => {
+      writeFileSync(
+        "appmap.yml",
+        YAML.stringify({
+          name: "test-package",
+          appmap_dir: "appmap",
+          packages: [{ path: "." }],
+        }),
+      );
+      const config = new Config();
+      config.migrate();
+
+      expect(readFileSync("appmap.yml").toString()).toMatchSnapshot();
+    });
+
+    it("does not update an existing config if the language field is already set", () => {
+      const appmapYml = YAML.stringify({
+        name: "test-package",
+        language: "ruby",
+        appmap_dir: "appmap",
+        packages: [{ path: "." }],
+      });
+
+      writeFileSync("appmap.yml", appmapYml);
+      const config = new Config();
+      config.migrate();
+
+      expect(readFileSync("appmap.yml").toString()).toMatchSnapshot();
+    });
   });
 
   let dir: string;

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -33,6 +33,7 @@ export function main() {
     info("Writing default config to %s", config.configPath);
     writeFileSync(config.configPath, YAML.stringify(config));
   } else info("Using config file %s", config.configPath);
+  config.migrate();
   config.export();
 
   // FIXME: Probably there should be a way to remove this altogether

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,6 +140,8 @@ export class Config {
       this.configPath,
       YAML.stringify(this.document ?? this, { keepSourceTokens: true }),
     );
+
+    this.migrationPending = false;
   }
 }
 

--- a/test/__snapshots__/simple.test.ts.snap
+++ b/test/__snapshots__/simple.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`creating a default config file 1`] = `
 "name: test
+language: javascript
 appmap_dir: tmp/appmap
 packages:
   - path: .

--- a/test/codeBlock/appmap.yml
+++ b/test/codeBlock/appmap.yml
@@ -1,2 +1,3 @@
 name: codeBlock
 appmap_dir: tmp/appmap
+language: javascript

--- a/test/functionLabels/appmap.yml
+++ b/test/functionLabels/appmap.yml
@@ -1,6 +1,6 @@
 name: function-labels-appmap-node-test
 appmap_dir: tmp/appmap
-packages: 
+packages:
   - path: .
   - module: node:console
     shallow: true
@@ -12,6 +12,7 @@ packages:
       - name: log
         label: logging
       - name: debug
-        labels: 
+        labels:
           - logging
           - debugging
+language: javascript

--- a/test/httpClient/appmap.yml
+++ b/test/httpClient/appmap.yml
@@ -1,3 +1,4 @@
 name: http-client-appmap-node-test
 appmap_dir: tmp/appmap
 response_body_max_length: 50
+language: javascript

--- a/test/httpServer/appmap.yml
+++ b/test/httpServer/appmap.yml
@@ -1,2 +1,3 @@
 name: http-server-appmap-node-test
 appmap_dir: tmp/appmap
+language: javascript

--- a/test/jest/appmap.yml
+++ b/test/jest/appmap.yml
@@ -1,2 +1,3 @@
 name: jest-appmap-node-test
 appmap_dir: tmp/appmap
+language: javascript

--- a/test/libraryCalls/appmap.yml
+++ b/test/libraryCalls/appmap.yml
@@ -6,6 +6,7 @@ packages:
     shallow: true
   - module: node:console # works with or without node: qualifier
     shallow: true
-    exclude: 
+    exclude:
       - warn
       - assert # exclude because this is captured only in windows
+language: javascript

--- a/test/mocha/appmap.yml
+++ b/test/mocha/appmap.yml
@@ -1,2 +1,3 @@
 name: mocha-appmap-node-test
 appmap_dir: tmp/appmap
+language: javascript

--- a/test/mysql/appmap.yml
+++ b/test/mysql/appmap.yml
@@ -1,2 +1,3 @@
 name: mysql-appmap-node-test
 appmap_dir: tmp/appmap
+language: javascript

--- a/test/next/appmap.yml
+++ b/test/next/appmap.yml
@@ -5,3 +5,4 @@ packages:
     exclude:
       - node_modules
       - .yarn
+language: javascript

--- a/test/prisma/appmap.yml
+++ b/test/prisma/appmap.yml
@@ -1,2 +1,3 @@
 name: prisma-appmap-node-test
 appmap_dir: tmp/appmap
+language: javascript

--- a/test/simple/appmap.yml
+++ b/test/simple/appmap.yml
@@ -1,7 +1,8 @@
 name: simple
 appmap_dir: tmp/appmap
 packages:
-- path: .
-  exclude:
-  - skipped
-  - A.skippedMethod
+  - path: .
+    exclude:
+      - skipped
+      - A.skippedMethod
+language: javascript

--- a/test/sqlite/appmap.yml
+++ b/test/sqlite/appmap.yml
@@ -1,2 +1,3 @@
 name: sqlite-appmap-node-test
 appmap_dir: tmp/appmap
+language: javascript

--- a/test/typescript-esm/appmap.yml
+++ b/test/typescript-esm/appmap.yml
@@ -5,3 +5,4 @@ packages:
     exclude:
       - node_modules
       - .yarn
+language: javascript

--- a/test/typescript/appmap.yml
+++ b/test/typescript/appmap.yml
@@ -1,2 +1,3 @@
 name: appmap-node
 appmap_dir: tmp/appmap
+language: javascript

--- a/test/vitest/appmap.yml
+++ b/test/vitest/appmap.yml
@@ -1,2 +1,3 @@
 name: vitest-appmap-node-test
 appmap_dir: tmp/appmap
+language: javascript


### PR DESCRIPTION
By default, this is set to `javascript`. Any existing configurations will be migrated automatically.