### PR TITLE
fix: Handle exceptions raised by getters during parameter serialization

### DIFF
--- a/src/__tests__/parameter.test.ts
+++ b/src/__tests__/parameter.test.ts
@@ -86,4 +86,21 @@ describe(parameter, () => {
     obj.items = [obj];
     expect(parameter(obj).class).toBe("Object");
   });
+
+  it('does not throw on "get" trap', () => {
+    const sentinelValue = new Proxy(
+      {},
+      {
+        get: () => {
+          throw new Error(`don't call me`);
+        },
+      },
+    );
+    const result = parameter(sentinelValue);
+    expect(result).toStrictEqual({
+      class: "unknown",
+      object_id: expect.any(Number), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+      value: "{}",
+    });
+  });
 });

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -95,8 +95,12 @@ function parameterSchema(value: unknown, objectsSeen?: Set<object>): AppMap.Para
 }
 
 function isSimpleObject(value: unknown): value is Record<string, unknown> {
-  if (!(value && typeof value === "object")) return false;
-  return Object.getPrototypeOf(value) === null || value.constructor === Object;
+  try {
+    if (!(value && typeof value === "object")) return false;
+    return Object.getPrototypeOf(value) === null || value.constructor === Object;
+  } catch {
+    return false;
+  }
 }
 
 function itemsSchema(


### PR DESCRIPTION
This change addresses an issue where exceptions raised by getters during parameter serialization were not handled properly. A test case was added to ensure that the parameter function does not throw an error when encountering a "get" trap, and the `isSimpleObject` function was updated to catch exceptions and return false if an error occurs.

This pull request ensures stability when dealing with objects that have getters that could potentially throw exceptions, preventing crashes and ensuring that such objects are treated as non-simple.

E.g. https://github.com/nestjs/nest/blob/233a89ab3d84d814bb795f738be15216f5b30ed9/packages/common/module-utils/configurable-module.builder.ts#L331-L346

Fixes #158