### PR TITLE
fix: Check APPMAP_RECORDER_PROCESS_ALWAYS truthy value

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -13,7 +13,16 @@ import { FunctionInfo } from "./registry";
 import commonPathPrefix from "./util/commonPathPrefix";
 import { getTime } from "./util/getTime";
 
-const processRecordingShouldAlwaysBeActive = "APPMAP_RECORDER_PROCESS_ALWAYS" in process.env;
+const kAppmapRecorderProcessAlwaysEnvar = "APPMAP_RECORDER_PROCESS_ALWAYS";
+const processRecordingShouldAlwaysBeActive = isTruthy(
+  process.env[kAppmapRecorderProcessAlwaysEnvar],
+);
+
+function isTruthy(value?: string): boolean {
+  if (value == undefined) return false;
+  const truthyValues = ["true", "1", "on", "yes"];
+  return truthyValues.includes(value.toLowerCase().trim());
+}
 
 // If APPMAP_RECORDER_PROCESS_ALWAYS is set we can have
 // two recordings active simultaneously. Always active


### PR DESCRIPTION
This PR updates the interpretation of the `APPMAP_RECORDER_PROCESS_ALWAYS` environment variable so that process recording remains active only if the variable is set to a truthy value (one of ‘true’, ‘1’, ‘on’, ‘yes’).

Previously, the existence of the `APPMAP_RECORDER_PROCESS_ALWAYS` environment variable, regardless of its value, was interpreted as true.

---

Behavior regarding this environment variable is as follows:

### Default Behavior (When `APPMAP_RECORDER_PROCESS_ALWAYS` is not set to a truthy value)

When the `APPMAP_RECORDER_PROCESS_ALWAYS` environment variable is not set to one of the truthy values (`true`, `1`, `on`, `yes`), `appmap-node` behaves as follows:

`appmap-node` initially creates a process recording AppMap for the entire process. If `appmap-node` detects a request, a test or a remote recording, it abandons the process recording. Instead, for example, if requests are detected, it creates individual request recordings for each detected request. In this case, you end up with multiple request recordings (one per request) and no process recording. Otherwise there will be just one process recording AppMap.

### Behavior with `APPMAP_RECORDER_PROCESS_ALWAYS` set to a truthy Value

When `APPMAP_RECORDER_PROCESS_ALWAYS` is set to one of the truthy values (`true`, `1`, `on`, `yes`):

`appmap-node` continues to record the entire process even when a request, a test or a remote recording is detected. As a result, for example, if requests are detected, you get one process recording AppMap that covers the entire process and multiple request recording AppMaps, with one AppMap for each request.

