### PR TITLE
fix: Crash in emit attempt when stream closed

### DIFF
--- a/src/__tests__/Recording.test.ts
+++ b/src/__tests__/Recording.test.ts
@@ -84,6 +84,16 @@ afterEach(() => {
   resetObjectIds();
 });
 
+describe("Recording", () => {
+  it("Does not throw when emit is called with stream closed", () => {
+    const recording = new Recording("tests", "test", "test");
+    const funInfo = createTestFn("testFun");
+    const call = recording.functionCall(funInfo, undefined, []);
+    recording.finish();
+    recording.functionReturn(call.id, "result", undefined);
+  });
+});
+
 jest.mock("../AppMapStream");
 
 // DO NOT REMOVE!


### PR DESCRIPTION
Fixes #164.

This PR checks if the stream is undefined (AppMap finished or abandoned) when an event is emitted. If so, prevents crash by issuing a warning and omitting the event.

