### PR TITLE
fix: Crashes due to shadowed global scope object

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,12 @@ export class Config {
   // If it's 0 then no async tracking.
   public readonly asyncTrackingTimeout: number;
 
+  // This flag controls whether a check is generated for the existence
+  // of the AppMap record function in the global namespace. The check prevents
+  // crashes in environments where the global/globalThis object is shadowed or
+  // manipulated. This flag allows easy toggling of the check during testing.
+  public readonly generateGlobalRecordHookCheck: boolean = true;
+
   private readonly document?: Document;
   private migrationPending = false;
 

--- a/src/hooks/__tests__/instrument.test.ts
+++ b/src/hooks/__tests__/instrument.test.ts
@@ -52,8 +52,11 @@ describe(instrument.transform, () => {
           "static": true
         }];
 
+        ${instrument.__appmapRecordInitFunctionDeclarationCode}
+        ${instrument.__appmapRecordVariableDeclarationCode}
+
         function testFun(arg) {
-          return global.AppMapRecordHook.call(this, () => {
+          return __appmapRecord.call(this, () => {
             return arg + 1;
           }, arguments, __appmapFunctionRegistry[0]);
         }
@@ -92,9 +95,12 @@ describe(instrument.transform, () => {
           }
         }];
 
+        ${instrument.__appmapRecordInitFunctionDeclarationCode}
+        ${instrument.__appmapRecordVariableDeclarationCode}
+
         class TestClass {
           foo(value) {
-            return global.AppMapRecordHook.call(this, () => {
+            return __appmapRecord.call(this, () => {
               return value + 1;
             }, arguments, __appmapFunctionRegistry[0]);
           }
@@ -175,7 +181,10 @@ describe(instrument.transform, () => {
         },
       ];
 
-      const outer = (...$appmap$args) => global.AppMapRecordHook.call(
+      ${instrument.__appmapRecordInitFunctionDeclarationCode}
+      ${instrument.__appmapRecordVariableDeclarationCode}
+
+      const outer = (...$appmap$args) => __appmapRecord.call(
         undefined,
         (arg) => arg + 42,
         $appmap$args,
@@ -183,13 +192,13 @@ describe(instrument.transform, () => {
       );
 
       export const testFun = (...$appmap$args) =>
-        global.AppMapRecordHook.call(
+        __appmapRecord.call(
           undefined,
           (arg) => {
             var s42 = y => y - 42;
             let s43 = y => y - 43;
             const inner = (...$appmap$args) =>
-              global.AppMapRecordHook.call(
+              __appmapRecord.call(
                 undefined,
                 (x) => s42(x) * 2,
                 $appmap$args,
@@ -255,12 +264,15 @@ describe(instrument.transform, () => {
         },
       ];
 
+      ${instrument.__appmapRecordInitFunctionDeclarationCode}
+      ${instrument.__appmapRecordVariableDeclarationCode}
+
       exports.testFun = (...$appmap$args) =>
-        global.AppMapRecordHook.call(
+        __appmapRecord.call(
           undefined,
           (arg) => {
             const inner = (...$appmap$args) =>
-              global.AppMapRecordHook.call(
+              __appmapRecord.call(
                 undefined,
                 (x) => x * 2,
                 $appmap$args,
@@ -303,8 +315,11 @@ describe(instrument.transform, () => {
           "klassOrFile": "test",
           "static": true
         }];
-
-        const testFun = (...$appmap$args) => global.AppMapRecordHook.call(undefined, x => x * 2,
+        
+        ${instrument.__appmapRecordInitFunctionDeclarationCode}
+        ${instrument.__appmapRecordVariableDeclarationCode}
+        
+        const testFun = (...$appmap$args) => __appmapRecord.call(undefined, x => x * 2,
           $appmap$args, __appmapFunctionRegistry[0]);
 
         exports.testFun = testFun;

--- a/test/__snapshots__/simple.test.ts.snap
+++ b/test/__snapshots__/simple.test.ts.snap
@@ -828,6 +828,81 @@ exports[`mapping a script with import attributes/assertions 1`] = `
 }
 `;
 
+exports[`mapping a script with shadowed global object 1`] = `
+{
+  "classMap": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "location": "global.js:3",
+              "name": "shadow",
+              "static": true,
+              "type": "function",
+            },
+          ],
+          "name": "global",
+          "type": "class",
+        },
+      ],
+      "name": "simple",
+      "type": "package",
+    },
+  ],
+  "events": [
+    {
+      "defined_class": "global",
+      "event": "call",
+      "id": 1,
+      "lineno": 3,
+      "method_id": "shadow",
+      "parameters": [
+        {
+          "class": "String",
+          "name": "global",
+          "value": "'Hello'",
+        },
+        {
+          "class": "String",
+          "name": "globalThis",
+          "value": "'World'",
+        },
+      ],
+      "path": "global.js",
+      "static": true,
+      "thread_id": 0,
+    },
+    {
+      "elapsed": 31.337,
+      "event": "return",
+      "id": 2,
+      "parent_id": 1,
+      "thread_id": 0,
+    },
+  ],
+  "metadata": {
+    "app": "simple",
+    "client": {
+      "name": "appmap-node",
+      "url": "https://github.com/getappmap/appmap-node",
+      "version": "test node-appmap version",
+    },
+    "language": {
+      "engine": "Node.js",
+      "name": "javascript",
+      "version": "test node version",
+    },
+    "name": "test process recording",
+    "recorder": {
+      "name": "process",
+      "type": "process",
+    },
+  },
+  "version": "1.12",
+}
+`;
+
 exports[`mapping a script with tangled async functions 1`] = `
 {
   "classMap": [

--- a/test/simple.test.ts
+++ b/test/simple.test.ts
@@ -87,6 +87,11 @@ integrationTest("mapping a custom Error class with a message property", () => {
   expect(readAppmap()).toMatchSnapshot();
 });
 
+integrationTest("mapping a script with shadowed global object", () => {
+  expect(runAppmapNode("global.js").status).toBe(0);
+  expect(readAppmap()).toMatchSnapshot();
+});
+
 integrationTestSkipOnWindows("finish signal is handled", async () => {
   const server = spawnAppmapNode("server.mjs");
   await new Promise<void>((r) =>

--- a/test/simple/global.js
+++ b/test/simple/global.js
@@ -1,0 +1,7 @@
+const global = "Hello";
+
+function shadow(global, globalThis) {
+  console.log(global, globalThis);
+}
+
+shadow(global, "World");


### PR DESCRIPTION
Fixes #159.

#### Summary
This pull request addresses an essential issue by changing instrumentation to prevent potential crashes in environments where `global` or `globalThis` objects are shadowed or manipulated. These updates ensure the stability and reliability of the AppMap recording functionality.

#### Original Code Example
 ```javascript
function testFun(arg) {
  return arg + 1;
}
 ```

#### Transformation Before This Fix
 ```javascript
 function testFun(arg) {
   return global.AppMapRecodHook.call(this, () => {
     return arg + 1;
   }, arguments, __appmapFunctionRegistry[0]);
 }
 ```
#### Transformation After This Fix

 ```javascript

 // These are added to the top of the module/script

function __appmapRecordInit() {
  let g = null;
  try {
    g = global.AppMapRecordHook;
  } catch (e) {
    try {
      g = globalThis.AppMapRecordHook;
    } catch (e) {}
    // If global/globalThis is shadowed in the top level, we'll get:
    // ReferenceError: Cannot access 'global' before initialization.   
  }
  // Bypass recording if we can't access recorder to prevent a crash.
  return g ?? ((fun, argsArg) => fun.apply(this, argsArg));
}

const __appmapRecord = __appmapRecordInit();

// Not calling global.AppMapRecordHook directly in the function
// prevents shadowing error in the function and pushes the check
// to a single place where it is run just once in the module/script
// initialization.

 function testFun(arg) {
   return __appmapRecord.call(this, () => {
     return arg + 1;
   }, arguments, __appmapFunctionRegistry[0]);
 }
```
