### PR TITLE
fix: Preserve Unicode escape sequences in transformation

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -84,6 +84,7 @@ export default function transform(code: string, url: URL, hooks = defaultHooks):
       loc: true,
       module: true,
       onComment: comments,
+      raw: true,
     });
 
     const xformed = hook.transform(tree, getSourceMap_(), comments);


### PR DESCRIPTION
Fixes #172.

Ensures that Unicode escape sequences (e.g., "\u{1D306}") are correctly preserved during the code transformation process. This fix addresses an issue where certain escape sequences were incorrectly converted when parsing and regenerating code.

The fix gives `raw: true` option to the `meriyah` `parse` function in `transform.ts`. 

```typescript
 const tree = parse(code, {
   source: url.toString(),
   next: true,
   loc: true,
   module: true,
   onComment: comments,
   raw: true, // Added this line
 });
```

This test, which would fail without the fix, is added to `transform.test.ts`.

```typescript
it("transforms unicode correctly", () => {
  const input = `const a = "\\u{1D306}";\n`;
  // Ensure that "\u{1D306}" is not converted to "t̆".
  expect(transform(input, new URL("file:///foo"), [new IdentityHook()])).toBe(input);
});
```

