### PR TITLE
Remove npmMinimalAgeGate and update lodash dependencies

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,4 @@ enableGlobalCache: true
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 2880
-
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/yarn.lock
+++ b/yarn.lock
@@ -7948,9 +7948,9 @@ __metadata:
   linkType: hard
 
 "lodash-es@npm:^4.17.21":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10/1feae200df22eb0bd93ca86d485e77784b8a9fb1d13e91b66e9baa7a7e5e04be088c12a7e20c2250fc0bd3db1bc0ef0affc7d9e3810b6af2455a3c6bf6dde59e
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10/8bfad225ef09ef42b04283cdaf7830efcc2ba29ae41b56501c74422155ee1ccaa1f0f6e8319def3451a1fe54dec501c8e4bee622bae2b2d98ac993731e0a5cce
   languageName: node
   linkType: hard
 
@@ -7990,9 +7990,9 @@ __metadata:
   linkType: hard
 
 "lodash@npm:^4.17.4":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Remove `npmMinimalAgeGate` from yarn config: the 48h age gate delays security patches by the same margin it delays malicious packages, which is counterproductive. It guards against a narrow attack window that yarn.lock already mitigates for existing installs. For a dev-only toolchain that doesn't ship to end users, the cost outweighs the benefit.

(I thought it would be a good idea to add it, but I changed my mind.)

Also, update lodash to 4.18.1.