### PR TITLE
ci: Cancel in-progress workflow runs on branch push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: Lint and test
 
 on: push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-and-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a `concurrency` block to the top-level configuration of the lint and test workflow. This groups runs by workflow and branch reference (`${{ github.workflow }}-${{ github.ref }}`) and enables automatic cancellation of active runs on any push (`cancel-in-progress: true`), while keeping the `main` branch protected from cancellation.

Assisted-by: Gemini CLI:gemini-3.5-flash